### PR TITLE
[ci skip] adding user @wtclarke

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @wexeee
+* @wtclarke

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,4 +48,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - wtclarke
     - wexeee


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @wtclarke as instructed in #10.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #10