### PR TITLE
MNT: Add FSL entry points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - spec2nii = spec2nii.spec2nii:main

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,3 @@
+if  [ -e ${FSLDIR}/share/fsl/sbin/createFSLWrapper ]; then
+  $FSLDIR/share/fsl/sbin/createFSLWrapper spec2nii
+fi

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,0 +1,3 @@
+if  [ -e ${FSLDIR}/share/fsl/sbin/removeFSLWrapper ]; then
+  $FSLDIR/share/fsl/sbin/removeFSLWrapper spec2nii
+fi


### PR DESCRIPTION
Hi @wtclarke,

For FSL installations, we add entry points for all FSL commands into `$FSLDIR/share/fsl/bin/`, to isolate FSL commands from all of the other commands that are installed into the `$FSLDIR/bin/` directory. We do this via conda's [`post-link` mechanism](https://docs.conda.io/projects/conda-build/en/latest/resources/link-scripts.html).

This PR adds `post-link.sh` and `pre-unlink.sh` scripts for `spec2nii`, so that it will be available to users who have a standard FSL installation (where `$FSLDIR/share/fsl/bin/` is added to their `$PATH` rather than `$FSLDIR/bin/`). The link scripts will have no effect when `spec2nii` is installed into a regular conda environment.

Thanks!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
